### PR TITLE
Fix podchecker warnings

### DIFF
--- a/lib/Test/Script.pm
+++ b/lib/Test/Script.pm
@@ -326,7 +326,7 @@ sub _like
 =head2 script_stdout_is
 
  script_stdout_is $expected_stdout, $test_name;
- 
+
 Tests if the output to stdout from the previous L</script_runs> matches the 
 expected value exactly.
 
@@ -342,7 +342,7 @@ sub script_stdout_is
 =head2 script_stdout_isnt
 
  script_stdout_is $expected_stdout, $test_name;
- 
+
 Tests if the output to stdout from the previous L</script_runs> does NOT match the 
 expected value exactly.
 
@@ -390,7 +390,7 @@ sub script_stdout_unlike
 =head2 script_stderr_is
 
  script_stderr_is $expected_stderr, $test_name;
- 
+
 Tests if the output to stderr from the previous L</script_runs> matches the 
 expected value exactly.
 
@@ -406,7 +406,7 @@ sub script_stderr_is
 =head2 script_stderr_isnt
 
  script_stderr_is $expected_stderr, $test_name;
- 
+
 Tests if the output to stderr from the previous L</script_runs> does NOT match the 
 expected value exactly.
 


### PR DESCRIPTION
`podchecker` noticed the following warning:

    line containing nothing but whitespace in paragraph

This change removes the offending characters and now `podchecker` reports neither warning nor error.

This PR is submitted in the hope that it is helpful.  If you have any questions or comments regarding it, please don't hesitate to contact me.