### PR TITLE
Use LF line endings when checking out files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,3 @@
 *.t linguist-language=Perl
+*.t text eol=lf
+*.pl text eol=lf


### PR DESCRIPTION
When running the test suite (via `dzil test`) in the Windows command shell, I found that the `xt/eol.t` tests were failing on the `t/*.t` and `t/bin/*.pl` files, due to the fact that the files were checked out with DOS line endings.  By setting the `eol` attribute appropriately (as proposed in this PR), this problem can be avoided.

It also turns out that one can add the lines:

```
[Run::BeforeBuild]
run = dos2unix t/*.t t/bin/*.pl
```

to the `dist.ini`, however it seemed that the `gitattributes` solution was the slighltly cleaner version.

This PR is submitted in the hope that it is useful.  If you have any questions or comments, or wish for it to be updated in any way, please don't hesitate to contact me.