### PR TITLE
Add Appveyor configuration

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,0 +1,15 @@
+cache:
+    - C:\Strawberry -> .appveyor_clear_cache.txt
+
+shallow_clone: true
+
+install:
+  - if not exist "C:\Strawberry" cinst strawberryperl
+  - set PATH=C:\strawberry\perl\bin;C:\strawberry\perl\site\bin;C:\strawberry\c\bin;%PATH%
+  - cd C:\projects\%APPVEYOR_PROJECT_NAME%
+  - cpanm Dist::Zilla
+  - dzil authordeps --missing | cpanm --force || type C:\Users\appveyor\.cpanm\build.log ; perl -e "exit 1"
+  - dzil listdeps --author --missing | cpanm || type C:\Users\appveyor\.cpanm\build.log ; perl -e "exit 1"
+
+build_script:
+  - dzil test --author --release


### PR DESCRIPTION
... which currently uses `cpanm --force` in the `dzil authordeps`
installation phase since `Dist::Zilla::Plugin::Run::BeforeBuild` has
build problems on Appveyor.  Beyond that, the distribution builds and
tests correctly.

If you would like something changed or updated in this PR, just let me know and I'll resubmit as necessary.