### PR TITLE
Add 'provides' info to META.yml

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -50,6 +50,8 @@ Probe::Perl = 0.01
 Test::Builder         = 0.32
 Test::Builder::Tester = 1.02
 
+[MetaProvides::Package]
+
 [Author::Plicease::Upload]
 cpan = 1
 


### PR DESCRIPTION
This change solves the 'meta_yml_has_provides' issue mentioned on the
[CPANTS](http://cpants.cpanauthors.org/dist/Test-Script) page for this
distribution.