### PR TITLE
Add missing File::Temp prerequisite

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -40,6 +40,7 @@ remove = File::Temp
 remove = File::Path
 
 [Prereqs]
+File::Temp  = 0
 File::Spec  = 0.80
 IPC::Run3   = 0.034
 Test::More  = 0.96

--- a/t/00_diag.t
+++ b/t/00_diag.t
@@ -12,6 +12,7 @@ my $post_diag;
 $modules{$_} = $_ for qw(
   ExtUtils::MakeMaker
   File::Spec
+  File::Temp
   IPC::Run3
   Probe::Perl
   Test::Builder


### PR DESCRIPTION
This solves the 'prereq matches use'
[CPANTS](http://cpants.cpanauthors.org/dist/Test-Script) issue for this
distribution.

I haven't set a definite `File::Temp` version since it's not clear to me what the version really should be (and is probably more obvious to someone more familiar with the dist).  Nevertheless, this change fixes a CPANTS issue and, if a better `File::Temp` version can be used, then will hopefully provide an improvement to the dist.

If you wish for the PR to be changed in any way, please just let me know and I'll update and resubmit.