### PR TITLE
Purge trailing whitespace in source files

### DIFF
--- a/Changes
+++ b/Changes
@@ -35,11 +35,11 @@ Revision history for Perl extension {{$dist->name}}
   - Check for IO errors on temporary .pm file
 
 1.11_02   2016-04-27 13:15:35 -0400
-  - One possible fix for gh#5 
+  - One possible fix for gh#5
     (see https://github.com/plicease/Test-Script/issues/5)
 
 1.11_01   2016-04-27 12:28:33 -0400
-  - Including some optional Test2 based tests that should 
+  - Including some optional Test2 based tests that should
     only be run with a merged Test2 / Test::Builder
     (currently a dev release as Test::Simple on CPAN)
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Basic cross-platform tests for scripts
 
     use Test::More tests => 2;
     use Test::Script;
-    
+
     script_compiles('script/myscript.pl');
     script_runs(['script/myscript.pl', '--my-argument']);
 
@@ -97,7 +97,7 @@ You may pass in options as a hash as the second argument.
 
     Where to send the standard output to.  If you use this option, then the the
     behavior of the `script_stdout_` functions below are undefined.  The value
-    may be one of 
+    may be one of
 
     - simple scalar
 
@@ -118,14 +118,14 @@ You may pass in options as a hash as the second argument.
 
     script_stdout_is $expected_stdout, $test_name;
 
-Tests if the output to stdout from the previous ["script\_runs"](#script_runs) matches the 
+Tests if the output to stdout from the previous ["script\_runs"](#script_runs) matches the
 expected value exactly.
 
 ## script\_stdout\_isnt
 
     script_stdout_is $expected_stdout, $test_name;
 
-Tests if the output to stdout from the previous ["script\_runs"](#script_runs) does NOT match the 
+Tests if the output to stdout from the previous ["script\_runs"](#script_runs) does NOT match the
 expected value exactly.
 
 ## script\_stdout\_like
@@ -146,14 +146,14 @@ expression.
 
     script_stderr_is $expected_stderr, $test_name;
 
-Tests if the output to stderr from the previous ["script\_runs"](#script_runs) matches the 
+Tests if the output to stderr from the previous ["script\_runs"](#script_runs) matches the
 expected value exactly.
 
 ## script\_stderr\_isnt
 
     script_stderr_is $expected_stderr, $test_name;
 
-Tests if the output to stderr from the previous ["script\_runs"](#script_runs) does NOT match the 
+Tests if the output to stderr from the previous ["script\_runs"](#script_runs) does NOT match the
 expected value exactly.
 
 ## script\_stderr\_like

--- a/lib/Test/Script.pm
+++ b/lib/Test/Script.pm
@@ -7,7 +7,7 @@ package Test::Script;
 
  use Test::More tests => 2;
  use Test::Script;
- 
+
  script_compiles('script/myscript.pl');
  script_runs(['script/myscript.pl', '--my-argument']);
 
@@ -176,10 +176,10 @@ sub _preload_module
   # this is hopefully a pm file that nobody would use
   my $filename = File::Spec->catfile($dir, '__TEST_SCRIPT__.pm');
   my $fh;
-  open($fh, '>', $filename) 
+  open($fh, '>', $filename)
     || die "unable to open $filename: $!";
   print($fh 'unshift @INC, ',
-    join ',', 
+    join ',',
     # quotemeta is overkill, but it will make sure that characters
     # like " are quoted
     map { '"' . quotemeta($_) . '"' }
@@ -245,7 +245,7 @@ L<IPC::Run3>, but that may change in the future).
 
 Where to send the standard output to.  If you use this option, then the the
 behavior of the C<script_stdout_> functions below are undefined.  The value
-may be one of 
+may be one of
 
 =over 4
 
@@ -303,10 +303,10 @@ sub script_runs {
 sub _like
 {
   my($text, $pattern, $regex, $not, $name) = @_;
-  
+
   my $ok = $regex ? $text =~ $pattern : $text eq $pattern;
   $ok = !$ok if $not;
-  
+
   my $test = Test::Builder->new;
   $test->ok( $ok, $name );
   unless($ok) {
@@ -319,7 +319,7 @@ sub _like
       $test->diag( "  $_" ) for split /\n/, $pattern;
     }
   }
-  
+
   $ok;
 }
 
@@ -327,7 +327,7 @@ sub _like
 
  script_stdout_is $expected_stdout, $test_name;
  
-Tests if the output to stdout from the previous L</script_runs> matches the 
+Tests if the output to stdout from the previous L</script_runs> matches the
 expected value exactly.
 
 =cut
@@ -343,7 +343,7 @@ sub script_stdout_is
 
  script_stdout_is $expected_stdout, $test_name;
  
-Tests if the output to stdout from the previous L</script_runs> does NOT match the 
+Tests if the output to stdout from the previous L</script_runs> does NOT match the
 expected value exactly.
 
 =cut
@@ -366,7 +366,7 @@ expression.
 
 sub script_stdout_like
 {
-  my($pattern, $name) = @_;  
+  my($pattern, $name) = @_;
   @_ = ($stdout, $pattern, 1, 0, $name || 'stdout matches' );
   goto &_like;
 }
@@ -391,7 +391,7 @@ sub script_stdout_unlike
 
  script_stderr_is $expected_stderr, $test_name;
  
-Tests if the output to stderr from the previous L</script_runs> matches the 
+Tests if the output to stderr from the previous L</script_runs> matches the
 expected value exactly.
 
 =cut
@@ -407,7 +407,7 @@ sub script_stderr_is
 
  script_stderr_is $expected_stderr, $test_name;
  
-Tests if the output to stderr from the previous L</script_runs> does NOT match the 
+Tests if the output to stderr from the previous L</script_runs> does NOT match the
 expected value exactly.
 
 =cut
@@ -430,7 +430,7 @@ expression.
 
 sub script_stderr_like
 {
-  my($pattern, $name) = @_;  
+  my($pattern, $name) = @_;
   @_ = ($stderr, $pattern, 1, 0, $name || 'stderr matches' );
   goto &_like;
 }
@@ -487,7 +487,7 @@ sub _perl_args {
 
 sub _options {
   my %options = ref($_[0]->[0]) eq 'HASH' ? %{ shift @{ $_[0] } }: ();
-  
+
   $options{exit}   = 0        unless defined $options{exit};
   $options{signal} = 0        unless defined $options{signal};
   my $stdin = '';

--- a/t/06_exception.t
+++ b/t/06_exception.t
@@ -30,7 +30,7 @@ subtest script_runs => sub {
       name => 'Script t/bin/missing.pl runs',
     },
   );
-  
+
   note $result->{diag};
 
 };

--- a/t/07_signal.t
+++ b/t/07_signal.t
@@ -25,7 +25,7 @@ subtest 'runs' => sub {
       ok => 0,
     },
   );
-  
+
   note $r->{diag};
 
 };

--- a/t/09_capture_output.t
+++ b/t/09_capture_output.t
@@ -40,7 +40,7 @@ subtest 'stdout' => sub {
       },
       'script_stdout_is',
     );
-    note $r->{diag};    
+    note $r->{diag};
   };
 
   subtest 'not isnt' => sub {
@@ -52,7 +52,7 @@ subtest 'stdout' => sub {
       },
       'script_stdout_isnt',
     );
-    note $r->{diag};    
+    note $r->{diag};
   };
 
   subtest 'like' => sub {
@@ -65,7 +65,7 @@ subtest 'stdout' => sub {
       },
       'script_stdout_like',
     );
-    
+
   };
 
   subtest 'not like' => sub {
@@ -79,8 +79,8 @@ subtest 'stdout' => sub {
       'script_stdout_like',
     );
 
-    note $r->{diag};    
-    
+    note $r->{diag};
+
   };
 
   subtest 'unlike' => sub {
@@ -93,7 +93,7 @@ subtest 'stdout' => sub {
       },
       'script_stdout_unlike',
     );
-    
+
   };
 
   subtest 'not unlike' => sub {
@@ -106,8 +106,8 @@ subtest 'stdout' => sub {
       },
       'script_stdout_unlike',
     );
-    
-    note $r->{diag};    
+
+    note $r->{diag};
   };
 
 };
@@ -146,7 +146,7 @@ subtest 'stderr' => sub {
       },
       'script_stderr_is',
     );
-    note $r->{diag};    
+    note $r->{diag};
   };
 
   subtest 'not isnt' => sub {
@@ -158,7 +158,7 @@ subtest 'stderr' => sub {
       },
       'script_stderr_isnt',
     );
-    note $r->{diag};    
+    note $r->{diag};
   };
 
   subtest 'like' => sub {
@@ -171,7 +171,7 @@ subtest 'stderr' => sub {
       },
       'script_stderr_like',
     );
-    
+
   };
 
   subtest 'not like' => sub {
@@ -185,8 +185,8 @@ subtest 'stderr' => sub {
       'script_stderr_like',
     );
 
-    note $r->{diag};    
-    
+    note $r->{diag};
+
   };
 
   subtest 'unlike' => sub {
@@ -199,7 +199,7 @@ subtest 'stderr' => sub {
       },
       'script_stderr_unlike',
     );
-    
+
   };
 
   subtest 'not unlike' => sub {
@@ -212,8 +212,8 @@ subtest 'stderr' => sub {
       },
       'script_stderr_unlike',
     );
-    
-    note $r->{diag};    
+
+    note $r->{diag};
   };
 
 };

--- a/t2/bug_gh9.t
+++ b/t2/bug_gh9.t
@@ -4,9 +4,9 @@ use Test::Script;
 subtest 'non-distructive' => sub {
 
   my @foo = qw( foo bar baz );
-  
+
   my $bar = Test::Script::_script \@foo;
-  
+
   is(
     $bar,
     [qw( foo bar baz )],

--- a/t2/test_script__script_compiles.t
+++ b/t2/test_script__script_compiles.t
@@ -35,7 +35,7 @@ subtest 'good' => sub {
     },
     'script_compiles t/bin/good.pl It worked',
   );
-  
+
   is $rv, T(), 'script_compiles_ok returns true as convenience';
 };
 
@@ -100,17 +100,17 @@ subtest 'bad' => sub {
 subtest 'unreasonable number of libs' => sub {
 
   skip_all 'developer only test' unless $ENV{TEST_SCRIPT_DEV_TEST};
-  
+
   local @INC = @INC;
-  
+
   my $dir = tempdir( CLEANUP => 1 );
-  
+
   for(map { File::Spec->catfile($dir, $_) } 1..1000000)
   {
     #mkdir;
     push @INC, $_;
   }
-  
+
   script_compiles 't/bin/good.pl';
 
 };

--- a/t2/test_script__script_runs.t
+++ b/t2/test_script__script_runs.t
@@ -9,7 +9,7 @@ use File::Temp qw( tempdir );
 subtest 'good' => sub {
 
   my $rv;
-  
+
   is(
     intercept { $rv = script_runs 't/bin/good.pl' },
     array {
@@ -21,7 +21,7 @@ subtest 'good' => sub {
     },
     'script_runs t/bin/good.pl',
   );
-  
+
   is $rv, T(), 'script_compiles_ok returns true as convenience';
 
   is(
@@ -35,16 +35,16 @@ subtest 'good' => sub {
     },
     'script_runs t/bin/good.pl It worked',
   );
-  
+
   is $rv, T(), 'script_compiles_ok returns true as convenience';
-  
-  
+
+
 };
 
 subtest 'good' => sub {
 
   my $rv;
-  
+
   is(
     intercept { $rv = script_runs 't/bin/four.pl' },
     array {
@@ -61,7 +61,7 @@ subtest 'good' => sub {
     },
     'script_runs t/bin/good.pl',
   );
-  
+
   is $rv, F(), 'script_compiles_ok returns false as convenience';
 
   is(
@@ -80,10 +80,10 @@ subtest 'good' => sub {
     },
     'script_runs t/bin/good.pl It worked',
   );
-  
+
   is $rv, F(), 'script_compiles_ok returns false as convenience';
-  
-  
+
+
 };
 
 subtest 'unreasonable number of libs' => sub {
@@ -97,7 +97,7 @@ subtest 'unreasonable number of libs' => sub {
     #mkdir;
     push @INC, $_;
   }
-  
+
   script_runs 't/bin/good.pl';
 
 };


### PR DESCRIPTION
Trailing whitespace is seen in some projects as bad practice (e.g. the Linux kernel) and is hence explicitly forbidden; other projects see its removal as plain nit-picking. This PR is submitted in the hope that it is helpful, however if you don't see any need to remove such whitespace I'm happy if you close the PR as unmerged. I've split up the PR into several commits so that the diffs are smaller; if you wish for the commits to be collected into one large commit (and thus reduce noise in the git history), just let me know and I'll rebase and force push an update to this branch. This change also ignores the whitespace changes as part of PR #14, so that the two PRs don't cause merge conflicts. If you have any questions or comments concerning the PR, please simply contact me!